### PR TITLE
Fix: -c command line option

### DIFF
--- a/pyqgisserver/server.py
+++ b/pyqgisserver/server.py
@@ -62,7 +62,8 @@ def read_configuration(args=None):
 
     log_level = args.logging
     if args.config:
-        read_config_file(args.config)
+        with open(args.config, mode='rt') as config_file:
+            read_config_file(config_file)
 
     read_config_dict({
         'logging':{ 'level'  : args.logging.upper() },


### PR DESCRIPTION
-c configfile did not work. The provided file name was supplied as a string where a file object was expected (ConfigParser.read_file(file)), therefore the file name was read one character by one where the file contents were expected to be read instead.
I replaced the call using the file name with a call using a file object opened on this file name.