### PR TITLE
Add a new option --version-full to get GDAL version etc used by QGIS-Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Add more information in the `--version` to display all versions related to QGIS Server : GDAL, PROJ, Qt…
+
 ## 1.7.16 - 2022-02-16
 
 * Add BAN cache observer
@@ -19,9 +21,9 @@
 * Ensure that exit code is non-zero on pool failure 
 * Set option to check for cache invalidation/refresh asynchronously
 * Use QgsProjectStorage for unhandled uri schemes
-    - This allow support for all QgsProjectStorage extensions
+    - This allows support for all QgsProjectStorage extensions
 * Add `ALLOW_STORAGE_SCHEMES` configuration for restricting allowed project schemes
-* Fix api managment:
+* Fix api management:
     - Follow backport for https://github.com/qgis/QGIS/issues/45439
     - Fix regression from static cache implementation
 

--- a/pyqgisserver/utils/qgis.py
+++ b/pyqgisserver/utils/qgis.py
@@ -169,7 +169,13 @@ def print_qgis_version(verbose: bool=False) -> None:
     """ Output the qgis version
     """
     from qgis.core import Qgis
-    print(f"Qgis {Qgis.QGIS_VERSION} '{Qgis.QGIS_RELEASE_NAME}' ({Qgis.QGIS_VERSION_INT})")
+
+    if Qgis.QGIS_VERSION_INT < 32200:
+        print(f"QGIS {Qgis.QGIS_VERSION} '{Qgis.QGIS_RELEASE_NAME}' ({Qgis.QGIS_VERSION_INT})")
+    else:
+        from qgis.core import QgsCommandLineUtils
+        print(QgsCommandLineUtils.allVersions(), file=sys.stderr)
+
     if verbose:
         start_qgis_application(verbose=True)
     


### PR DESCRIPTION
Only available for QGIS 3.22:

```
(.venv) etienne@latitude ~/dev/qgis/py-qgis-server (server_info) $ qgisserver --version-all
WARNING: Failed to load 'PSutil', system metrics will not be collected
QGIS 3.25.0-Master 'Master' (36a1019582)
QGIS code revision 36a1019582
Qt version 5.12.8
Python version 3.8.10
GDAL/OGR version 3.0.4
PROJ version 6.3.1
EPSG Registry database version v9.8.6 (2020-01-22)
Compiled against GEOS 3.8.0-CAPI-1.13.1
Running against GEOS 3.8.0-CAPI-1.13.1 
SQLite version 3.31.1
OS Ubuntu 20.04.4 LTS
This copy of QGIS writes debugging output.
```

@dmarteau Is-it ok ?
