### PR TITLE
handler: Set 'X-Map-Location' header if provided

### DIFF
--- a/pyqgisserver/handlers/asynchandler.py
+++ b/pyqgisserver/handlers/asynchandler.py
@@ -84,6 +84,9 @@ class AsyncClientHandler(BaseHandler):
             else:
                 req_url = self.request.uri
 
+            if self.request.headers.get('X-Map-Location', None):
+                headers['X-Map-Location'] = self.request.headers['X-Map-Location']
+
             self.set_backend_headers(headers)
 
             data = self.request.body


### PR DESCRIPTION
'X-Map-Location' can contain the QGIS project file url. It is then used in `QgsRequestHandler::handle_message()`.

