### PR TITLE
management: Add support for a proxy url

### DIFF
--- a/pyqgisserver/config.py
+++ b/pyqgisserver/config.py
@@ -174,6 +174,7 @@ def load_configuration():
     CONFIG.set('management', 'ss_key', getenv('QGSRV_MANAGEMENT_SSL_KEY', ''))
     CONFIG.set('management', 'ssl_cert', getenv('QGSRV_MANAGEMENT_SSL_CERT', ''))
     CONFIG.set('management', 'port', getenv('QGSRV_MANAGEMENT_PORT', '19876'))
+    CONFIG.set('management', 'proxy_url', getenv('QGSRV_MANAGEMENT_PROXY_URL', ''))
 
     #
     # Metadata

--- a/pyqgisserver/config.yml
+++ b/pyqgisserver/config.yml
@@ -426,6 +426,17 @@ config_options:
       section: management
       tags: [ http, management ]
 
+    - name: MANAGEMENT_PROXY_URL
+      label: Management proxy URL
+      description: |
+          The URL that must be seen by the client when the management service is
+          behind a proxy.
+      default: ''
+      type: string
+      key: proxy_url
+      section: management
+      tags: [ http, management, proxy ]
+
     - name: MANAGEMENT_SSL
       label: Enable SSL
       description: Enable SSL endpoint for API management

--- a/pyqgisserver/management/server.py
+++ b/pyqgisserver/management/server.py
@@ -84,14 +84,25 @@ class _ReportHandler(_PoolHandler):
 
 class _RootHandler(BaseHandler):
 
+    def initialize(self) -> None:
+        super().initialize()
+        config = confservice['management']
+        self.management_proxy_url = config['proxy_url'].strip('/')
+
     def get(self) -> None:
         """ Return links to default api entries
         """
         req = self.request
+        management_proxy_url = self.management_proxy_url
 
         def _link(path: str, title: str):
+            if management_proxy_url:
+                href = f"{management_proxy_url}{path}"
+            else:
+                href = f"{req.protocol}://{req.host}{path}"
+
             return {
-                'href': f"{req.protocol}://{req.host}{path}",
+                'href': href,
                 'title': title,
                 'type': "application/json",
             }


### PR DESCRIPTION
This is exposed with the new `QGSRV_MANAGEMENT_PROXY_URL` environment variable.
