### PR TITLE
asynchandler: Pass Accept header to properly handle WFS3 request

### DIFF
--- a/pyqgisserver/handlers/asynchandler.py
+++ b/pyqgisserver/handlers/asynchandler.py
@@ -64,6 +64,12 @@ class AsyncClientHandler(BaseHandler):
         # Pass etag
         headers['If-None-Match'] = self.request.headers.get("If-None-Match", "")
 
+        # Pass Accept
+        # This header is used by QGIS Server WFS3 to get the content type
+        # (html or json) if the request url does not have an extension
+        # See: QgsServerOgcApiHandler::contentTypeFromRequest()
+        headers['Accept'] = self.request.headers.get("Accept", "")
+
         def copy_headers(pats):
             headers.update((k, v) for k, v in self.request.headers.items() if
                            any(map(k.upper().startswith, pats)))


### PR DESCRIPTION
By default, a QGIS server wfs3 request returns an html response if the url does not contain an extension (html or json). However, `py-qgis-server` returns a response as json by default. This is because, QGIS server uses the `Accept` header to guess the correct format if the extension is not set (See
`QgsServerOgcApiHandler::contentTypeFromRequest()`).

This issue is fixed by copying the `Accept` header from the initial request to the request transmitted to QGIS server.

