### PR TITLE
makefile: Do not invoke setup.py directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,4 +70,3 @@ lint-fix:
 
 typing:
 	mypy --config-file=$(topsrcdir)/mypy.ini -p pyqgisserver
-

--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,8 @@ deliver:
 	twine upload $(TWINE_OPTIONS) -r $(PYPISERVER) $(DIST)/*
 
 dist: dirs configure
-	rm -rf *.egg-info
-	$(PYTHON) setup.py sdist --dist-dir=$(DIST)
+	rm -f $(DIST)/*.tar.gz
+	$(PYTHON) -m build --sdist --outdir=$(DIST)
 
 clean:
 	rm -rf $(DIST)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -11,3 +11,4 @@ types-psycopg2
 pipdeptree
 lxml
 lxml-stubs
+build


### PR DESCRIPTION
This is considered as deprecated. Use the "build" package instead.
See: https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html